### PR TITLE
QE-2488 Improve error handling in visual diff library

### DIFF
--- a/needle/cases.py
+++ b/needle/cases.py
@@ -250,3 +250,4 @@ class NeedleTestCase(TestCase):
                 else:
                     if self.cleanup_on_success:
                         os.remove(output_file)
+                    #commit test

--- a/needle/cases.py
+++ b/needle/cases.py
@@ -250,4 +250,3 @@ class NeedleTestCase(TestCase):
                 else:
                     if self.cleanup_on_success:
                         os.remove(output_file)
-                    #commit test


### PR DESCRIPTION
changes:

Modified error handling when pdiff is not setup properly and the dimensions of baseline and output are are not same